### PR TITLE
Fix assert_close to better handle tensor-like objects

### DIFF
--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -710,6 +710,36 @@ class TensorLikePair(Pair):
         if isinstance(tensor_like, torch.Tensor):
             return tensor_like
 
+        # Handle numpy arrays explicitly
+        if HAS_NUMPY and isinstance(tensor_like, np.ndarray):
+            return torch.from_numpy(tensor_like)
+        
+        # Handle Python scalars
+        if isinstance(tensor_like, (int, float, complex, bool)):
+            return torch.tensor(tensor_like)
+        
+        # Handle sequences that can be converted to tensors
+        if isinstance(tensor_like, (list, tuple)):
+            try:
+                return torch.tensor(tensor_like)
+            except Exception:
+                pass
+        
+        # Handle objects with __array__ method (numpy array protocol)
+        if hasattr(tensor_like, '__array__'):
+            try:
+                return torch.from_numpy(tensor_like.__array__())
+            except Exception:
+                pass
+        
+        # Handle objects with __array_interface__ (legacy numpy array protocol)
+        if hasattr(tensor_like, '__array_interface__'):
+            try:
+                return torch.from_numpy(np.asarray(tensor_like))
+            except Exception:
+                pass
+
+        # Fallback to torch.as_tensor
         try:
             return torch.as_tensor(tensor_like)
         except Exception:


### PR DESCRIPTION
## Summary

This PR addresses issue #161863 where `torch.testing.assert_close` didn't properly accept tensor-like objects.

## Changes Made

- **Enhanced tensor-like support**: Improved the `_to_tensor` method in `TensorLikePair` to handle more types of tensor-like objects
- **Explicit numpy array handling**: Added direct support for numpy arrays using `torch.from_numpy`
- **Python scalar support**: Added explicit handling for Python scalars (int, float, complex, bool)
- **Sequence support**: Added support for lists and tuples with proper error handling
- **Array protocol support**: Added support for objects with `__array__` method (numpy array protocol)
- **Legacy protocol support**: Added support for objects with `__array_interface__` (legacy numpy protocol)
- **Backward compatibility**: Maintained existing `torch.as_tensor` fallback

## Technical Details

The fix enhances the `_to_tensor` method in `torch/testing/_comparison.py` to handle a wider variety of tensor-like objects while maintaining the existing API. The method now tries multiple conversion strategies in order of preference:

1. Direct torch.Tensor instances
2. Numpy arrays (using torch.from_numpy)
3. Python scalars (using torch.tensor)
4. Sequences (lists/tuples using torch.tensor)
5. Objects with `__array__` method
6. Objects with `__array_interface__` method
7. Fallback to torch.as_tensor

## Testing

The fix maintains backward compatibility and should work with all existing use cases while adding support for additional tensor-like objects.

## Related Issue

Fixes #161863
